### PR TITLE
Update bytes variable after loop in add2_mem

### DIFF
--- a/gf256.cpp
+++ b/gf256.cpp
@@ -851,6 +851,8 @@ extern "C" void gf256_add2_mem(void * GF256_RESTRICT vz, const void * GF256_REST
         z16 = reinterpret_cast<GF256_M128 *>(z8 + count);
         x16 = reinterpret_cast<const GF256_M128 *>(x8 + count);
         y16 = reinterpret_cast<const GF256_M128 *>(y8 + count);
+
+        bytes -= (count * 8);
     }
 #else // GF256_TARGET_MOBILE
 # if defined(GF256_TRY_AVX2)


### PR DESCRIPTION
If `GF256_TARGET_MOBILE` was set and `GF256_TRY_NEON` wasn't `bytes` variable in `gf256_add2_mem` wasn't updated which resulted in trying to access bytes outside of the buffers if `bytes & 8 == 1`. 